### PR TITLE
Fix typo in ValidationError message

### DIFF
--- a/eventex/subscriptions/validators.py
+++ b/eventex/subscriptions/validators.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 
 def validate_cpf(value):
     if not value.isdigit():
-        raise ValidationError('CFP deve conter apenas números.', 'digits')
+        raise ValidationError('CPF deve conter apenas números.', 'digits')
 
     if len(value) != 11:
         raise ValidationError('CPF deve ter 11 números.', 'length')


### PR DESCRIPTION
Fixing typo in the text "CFP" for "CPF".